### PR TITLE
Add option to disable saving plot image and data

### DIFF
--- a/navicat_spock/helpers.py
+++ b/navicat_spock/helpers.py
@@ -414,6 +414,22 @@ def processargs(arguments):
         default=0,
         help="Plot and print the best volcano per descriptor. This is slow and writes a lot of plots, do not use unless you know what you are doing. (default: 0, False)",
     )
+    vbuilder.add_argument(
+        "--save_fig",
+        "-save_fig",
+        dest="save_fig",
+        type=bool,
+        default=0,
+        help="Save the volcano plot as an image. (default: 0, False)",
+    )
+    vbuilder.add_argument(
+        "--save_csv",
+        "-save_csv",
+        dest="save_csv",
+        type=bool,
+        default=0,
+        help="Save the volcano plot data to a CSV file. (default: 0, False)",
+    )
     args = vbuilder.parse_args(arguments)
 
     dfs = check_input(args.filenames, args.wp, args.imputer_strat, args.verb)
@@ -432,6 +448,8 @@ def processargs(arguments):
         args.plotmode,
         args.seed,
         args.prefit,
+        args.save_fig,
+        args.save_csv,
     )
 
 

--- a/navicat_spock/plotting2d.py
+++ b/navicat_spock/plotting2d.py
@@ -80,6 +80,7 @@ def plot_2d(
     breakpoints=None,
     estimates=None,
     plotmode=1,
+    save_fig=True,
 ):
     # Labels and key
     plt.xlabel(xlabel)
@@ -127,14 +128,15 @@ def plot_2d(
     ymin = bround(ymin, ybase, type="min")
     plt.ylim(ymin, ymax)
     plt.yticks(np.arange(ymin, ymax + 0.1, ybase))
-    plt.savefig(filename)
+    if save_fig:
+        plt.savefig(filename)
     if os.name != "posix" and "DISPLAY" in os.environ:
         plt.show()
     return fig, ax
 
 
 def plot_and_save(
-    pw_fit, tags, idx, tidx, cb, ms, plotmode, fig, ax, return_value=True
+    pw_fit, tags, idx, tidx, cb, ms, plotmode, fig, ax, return_value=True, save_fig=True, save_csv=True
 ):
     # Try to figure out good dimensions for the axes and ticks
     x = pw_fit.xx
@@ -180,17 +182,19 @@ def plot_and_save(
         estimates=estimates,
         plotmode=plotmode,
         filename=f"{namefixer(tags[idx].strip())}_volcano.png",
+        save_fig=save_fig,
     )
 
     # Pass in standard matplotlib keywords to control any of the plots
     # pw_fit.plot_breakpoint_confidence_intervals()
 
     # Print to file
-    zdata = list(zip(xint, yint))
-    csvname = f"{namefixer(tags[idx].strip())}_volcano.csv"
-    np.savetxt(
-        csvname, zdata, fmt="%.4e", delimiter=",", header="{tags[idx]},{tags[tidx]}"
-    )
+    if save_csv:
+        zdata = list(zip(xint, yint))
+        csvname = f"{namefixer(tags[idx].strip())}_volcano.csv"
+        np.savetxt(
+            csvname, zdata, fmt="%.4e", delimiter=",", header="{tags[idx]},{tags[tidx]}"
+        )
     if return_value:
         return fig, ax
     else:

--- a/navicat_spock/spock.py
+++ b/navicat_spock/spock.py
@@ -17,13 +17,14 @@ from navicat_spock.helpers import (
     n_iter_helper,
     slope_check,
 )
+
 from navicat_spock.exceptions import InputError, ConvergenceError
 from navicat_spock.piecewise_regression import ModelSelection, Fit
 from navicat_spock.plotting2d import plot_and_save
 
 
 def run_spock():
-    (df, wp, verb, imputer_strat, plotmode, seed, prefit) = processargs(sys.argv[1:])
+    (df, wp, verb, imputer_strat, plotmode, seed, prefit, save_fig, save_csv) = processargs(sys.argv[1:])
     _ = run_spock_from_args(
         df=df,
         wp=wp,
@@ -32,6 +33,8 @@ def run_spock():
         plotmode=plotmode,
         seed=seed,
         prefit=prefit,
+        save_fig=save_fig,
+        save_csv=save_csv,
     )
 
 
@@ -46,6 +49,8 @@ def run_spock_from_args(
     setcbms=True,
     fig=None,
     ax=None,
+    save_fig=True,
+    save_csv=True,
 ):
     if seed is None:
         seed = int(np.random.rand() * (2**32 - 1))
@@ -294,7 +299,7 @@ def run_spock_from_args(
                 pw_fit.summary()
             # Plot the data, fit, breakpoints and confidence intervals
             fig, ax = plot_and_save(
-                pw_fit, tags, idx, tidx, cb, ms, fig=fig, ax=ax, plotmode=plotmode
+                pw_fit, tags, idx, tidx, cb, ms, fig=fig, ax=ax, plotmode=plotmode, save_fig=save_fig, save_csv=save_csv
             )
             return fig, ax
         else:


### PR DESCRIPTION
I have enhanced the functionality to allow users to opt out of saving the plot image as a PNG file and the plot data as a CSV file. This improvement mainly helps prevent unnecessary disk usage on the [HuggingFace app](https://huggingface.co/spaces/nccr-catalysis/volcano-plot).

The default behavior of saving both files remains unchanged.